### PR TITLE
fix: route engine audio to outputs

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,11 @@
+# Noisebox Patch Review
+
+## Controller wiring
+- Every front-panel control is routed to a named parameter that the engine consumes. The oscillator frequency slider, waveform selector, and hold toggle all feed the frequency conditioning before the base pitch storage, while the LFO rate/wave/depth values drive the modulation generator.
+- Filter, delay, and feedback controls each arrive inside the engine to set the dual filters, delay time, modulation depth, and feedback amount, ensuring those sliders actively shape the signal chain.
+- Distortion range and volume sliders are read prior to the output stage; the processed signal is mirrored to the scope monitor and routed through the volume multipliers, confirming those UI elements are functional.
+- The frequency touch pad and oscilloscope subpatches are wired to update oscillator tuning and drive the display, so both non-slider controllers serve a purpose.
+
+## Audio path
+- The engine modulates the oscillator, passes it through the first filter, feeds the delay (with its own LFO and feedback), shapes the result with a second filter and wavefolding distortion, and finally applies the volume control before sending the stereo pair to `dac~`, yielding a complete audible signal path.
+

--- a/noisebox.pd
+++ b/noisebox.pd
@@ -41,8 +41,8 @@
 #X obj 960 340 pd freq-touch;
 #X obj 1060 780 dac~;
 #X connect 3 0 4 0;
-#X connect 33 0 36 0;
-#X connect 33 1 36 1;
+#X connect 20 0 23 0;
+#X connect 20 1 23 1;
 #N canvas 160 100 1180 880 engine 0;
 #X obj 40 40 r noisebox-osc-freq;
 #X obj 40 70 clip 20 8000;


### PR DESCRIPTION
## Summary
- connect the engine subpatch outlets to dac~ so the synth actually produces audio

## Testing
- not run (pure data patch)


------
https://chatgpt.com/codex/tasks/task_e_68d3ad231c6c8329bd703731d2ca5562